### PR TITLE
Add SQL schema for offers tables

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,18 @@
+-- offers_raw: każda znaleziona oferta
+CREATE TABLE IF NOT EXISTS offers_raw (
+  id INTEGER PRIMARY KEY,
+  origin TEXT, destination TEXT,
+  depart_date DATE, return_date DATE,
+  price_pln NUMERIC, airline TEXT,
+  stops INTEGER, total_time_h REAL, layover_h REAL,
+  deep_link TEXT, fetched_at DATETIME,
+  alert_sent INTEGER DEFAULT 0
+);
+
+-- offers_agg: średnie 30‑dniowe
+CREATE TABLE IF NOT EXISTS offers_agg (
+  origin TEXT, destination TEXT,
+  day DATE,
+  mean_price NUMERIC,
+  PRIMARY KEY (origin, destination, day)
+);


### PR DESCRIPTION
## Summary
- add `schema.sql` containing table definitions for `offers_raw` and `offers_agg`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871748017a4832d8178e1239e8eaa13