### PR TITLE
Add steal detection function and tests

### DIFF
--- a/sniper-main/steal_engine.py
+++ b/sniper-main/steal_engine.py
@@ -8,11 +8,18 @@ from aviasales_fetcher import FlightOffer
 
 
 def is_steal(offer: FlightOffer, cfg: Config) -> bool:
-    """Return ``True`` if *offer* price is a steal compared to recent average."""
+    """Return ``True`` if *offer* price is a steal compared to recent average.
+
+    Example:
+        >>> cfg.steal_threshold = 0.20
+        >>> is_steal(offer(price_pln=Decimal("800")), cfg)  # avg=1000
+        True
+    """
+
     avg = get_last_30d_avg(offer.origin, offer.destination)
-    if avg is None:
-        return False  # za mało danych
-    threshold = avg * Decimal(str(1 - cfg.steal_threshold))
+    if avg is None or avg <= 0:
+        return False
+    threshold = avg * (Decimal("1") - Decimal(cfg.steal_threshold))
     return offer.price_pln <= threshold
 
 

--- a/sniper-main/steal_engine.py
+++ b/sniper-main/steal_engine.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from config import Config
+from db import get_last_30d_avg
+from aviasales_fetcher import FlightOffer
+
+
+def is_steal(offer: FlightOffer, cfg: Config) -> bool:
+    """Return ``True`` if *offer* price is a steal compared to recent average."""
+    avg = get_last_30d_avg(offer.origin, offer.destination)
+    if avg is None:
+        return False  # za mało danych
+    threshold = avg * Decimal(str(1 - cfg.steal_threshold))
+    return offer.price_pln <= threshold
+
+
+__all__ = ["is_steal"]

--- a/sniper-main/tests/test_steal_engine.py
+++ b/sniper-main/tests/test_steal_engine.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from dataclasses import dataclass
+from decimal import Decimal
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from config import Config
+import steal_engine
+
+
+@dataclass(slots=True)
+class Offer:
+    origin: str
+    destination: str
+    price_pln: Decimal
+
+
+def test_is_steal_true(monkeypatch):
+    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: Decimal("100"))
+    offer = Offer("WAW", "JFK", Decimal("70"))
+    cfg = Config()
+    assert steal_engine.is_steal(offer, cfg)
+
+
+def test_is_steal_false_price(monkeypatch):
+    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: Decimal("100"))
+    offer = Offer("WAW", "JFK", Decimal("90"))
+    cfg = Config()
+    assert not steal_engine.is_steal(offer, cfg)
+
+
+def test_is_steal_no_data(monkeypatch):
+    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: None)
+    offer = Offer("WAW", "JFK", Decimal("50"))
+    cfg = Config()
+    assert not steal_engine.is_steal(offer, cfg)

--- a/sniper-main/tests/test_steal_engine.py
+++ b/sniper-main/tests/test_steal_engine.py
@@ -34,3 +34,10 @@ def test_is_steal_no_data(monkeypatch):
     offer = Offer("WAW", "JFK", Decimal("50"))
     cfg = Config()
     assert not steal_engine.is_steal(offer, cfg)
+
+
+def test_is_steal_non_positive_avg(monkeypatch):
+    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: Decimal("0"))
+    offer = Offer("WAW", "JFK", Decimal("10"))
+    cfg = Config()
+    assert not steal_engine.is_steal(offer, cfg)


### PR DESCRIPTION
## Summary
- implement `steal_engine.is_steal` for price comparison
- test steal detection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687179b46c40832daff18ce222589615