### PR TITLE
Implement daily aggregator script

### DIFF
--- a/sniper-main/aggregator.py
+++ b/sniper-main/aggregator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+
+from db import DB_FILE, upsert_daily_avg
+
+
+def aggregate(db_path: str = DB_FILE) -> None:
+    """Compute 30-day average price per route and store in ``offers_agg``."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.execute(
+        """
+        SELECT origin, destination, date(fetched_at) AS day, MIN(price_pln)
+        FROM offers_raw
+        WHERE date(fetched_at) >= date('now', '-30 day')
+        GROUP BY origin, destination, day
+        """
+    )
+    data: defaultdict[tuple[str, str], list[float]] = defaultdict(list)
+    for origin, dest, _day, min_price in cur.fetchall():
+        try:
+            data[(origin, dest)].append(float(min_price))
+        except (TypeError, ValueError):
+            continue
+    conn.close()
+
+    for (origin, dest), prices in data.items():
+        if not prices:
+            continue
+        mean_price = sum(prices) / len(prices)
+        upsert_daily_avg(origin, dest, mean_price, db_path=db_path)
+
+
+def main() -> None:
+    aggregate()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `aggregator.py` to compute 30‑day average prices
- compute daily averages and store them in `offers_agg`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68717c77ec34832d916b8b1c04d7f142