### PR TITLE
Add Config.from_json helper

### DIFF
--- a/sniper-main/config.py
+++ b/sniper-main/config.py
@@ -33,35 +33,35 @@ CONFIG_FIELDS = [
 ]
 
 
-def load_config(path: str | None = None) -> "Config":
-    """Return configuration loaded from *path* or ``config.json``."""
-    cfg_path = path or os.path.join(os.getcwd(), "config.json")
-    with open(cfg_path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+# def load_config(path: str | None = None) -> "Config":
+#     """Return configuration loaded from *path* or ``config.json``."""
+#     cfg_path = path or os.path.join(os.getcwd(), "config.json")
+#     with open(cfg_path, "r", encoding="utf-8") as fh:
+#         data = json.load(fh)
+#
+#     defaults = {
+#         "passengers": 1,
+#         "max_price_total": None,
+#         "excluded_airlines": [],
+#         "min_composite_score": 0,
+#         "weight_price": 0.4,
+#         "weight_price_per_km": 0.3,
+#         "weight_baseline_diff": 0.2,
+#         "weight_trip_duration": 0.1,
+#         "steal_threshold": 0.20,
+#         "max_stops": 1,
+#         "max_layover_h": 6.0,
+#         "poll_interval_h": 6,
+#         "currency": "PLN",
+#         "telegram_instant": True,
+#         "email_daily": True,
+#     }
+#
+#     cfg = {key: data.get(key, defaults.get(key)) for key in CONFIG_FIELDS}
+#     return Config(**{k: cfg[k] for k in Config.__dataclass_fields__})
 
-    defaults = {
-        "passengers": 1,
-        "max_price_total": None,
-        "excluded_airlines": [],
-        "min_composite_score": 0,
-        "weight_price": 0.4,
-        "weight_price_per_km": 0.3,
-        "weight_baseline_diff": 0.2,
-        "weight_trip_duration": 0.1,
-        "steal_threshold": 0.20,
-        "max_stops": 1,
-        "max_layover_h": 6.0,
-        "poll_interval_h": 6,
-        "currency": "PLN",
-        "telegram_instant": True,
-        "email_daily": True,
-    }
 
-    cfg = {key: data.get(key, defaults.get(key)) for key in CONFIG_FIELDS}
-    return Config(**{k: cfg[k] for k in Config.__dataclass_fields__})
-
-
-__all__ = ["load_config", "Config"]
+__all__ = ["Config"]
 
 
 @dataclass(slots=True)
@@ -73,10 +73,26 @@ class Config:
     steal_threshold: float = 0.20  # 20%
     max_stops: int = 1
     max_layover_h: float = 6.0
+    max_total_time_h: float = 30.0  # limit całkowitego czasu podróży (h)
     poll_interval_h: int = 6  # co 6 godz.
     currency: str = "PLN"
     telegram_instant: bool = True
     email_daily: bool = True
 
+    @classmethod
+    def from_json(cls, path: str = "config.json") -> "Config":
+        import json as _json
+        import pathlib
 
-__all__.append("Config")
+        from dataclasses import asdict
+
+        defaults = asdict(cls())
+        if pathlib.Path(path).exists():
+            with open(path, "r", encoding="utf-8") as f:
+                data = _json.load(f)
+                for key, value in data.items():
+                    if key in defaults:
+                        defaults[key] = value
+        return cls(**defaults)
+
+

--- a/sniper-main/tests/test_config.py
+++ b/sniper-main/tests/test_config.py
@@ -3,7 +3,7 @@ import sys
 import json
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from config import load_config, Config
+from config import Config
 
 
 def test_load_config(tmp_path):
@@ -22,7 +22,7 @@ def test_load_config(tmp_path):
     cfg_file = tmp_path / "config.json"
     cfg_file.write_text(json.dumps(cfg))
 
-    loaded = load_config(str(cfg_file))
+    loaded = Config.from_json(str(cfg_file))
     assert isinstance(loaded, Config)
     assert loaded.min_trip_days == 5
     assert loaded.max_trip_days == 15


### PR DESCRIPTION
## Summary
- deprecate `load_config` and provide `Config.from_json`
- support total trip time limit via `max_total_time_h`
- use new loader in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68718b0f4fd4832d943fb09422a7fcbd