### PR TITLE
Add aggregator test and adjust steal threshold test

### DIFF
--- a/sniper-main/tests/test_aggregator.py
+++ b/sniper-main/tests/test_aggregator.py
@@ -1,0 +1,44 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from datetime import datetime, timedelta
+import sqlite3
+
+import pytest
+
+from db import init_db
+import aggregator
+
+
+def test_aggregate_30_days_no_gaps(tmp_path):
+    db_file = tmp_path / "test.db"
+    schema_path = os.path.join(os.path.dirname(__file__), "..", "..", "schema.sql")
+    init_db(str(db_file), schema_path=schema_path)
+
+    conn = sqlite3.connect(db_file)
+    now = datetime.utcnow()
+    prices = []
+    for i in range(30):
+        dt = now - timedelta(days=i)
+        price = 100 + i
+        prices.append(price)
+        conn.execute(
+            "INSERT INTO offers_raw (origin, destination, price_pln, fetched_at) VALUES (?,?,?,?)",
+            ("WAW", "JFK", price, dt.isoformat()),
+        )
+    conn.commit()
+    conn.close()
+
+    aggregator.aggregate(str(db_file))
+
+    conn = sqlite3.connect(db_file)
+    cur = conn.execute(
+        "SELECT mean_price FROM offers_agg WHERE origin='WAW' AND destination='JFK'"
+    )
+    row = cur.fetchone()
+    conn.close()
+
+    assert row is not None
+    expected_avg = sum(prices) / len(prices)
+    assert float(row[0]) == pytest.approx(expected_avg)

--- a/sniper-main/tests/test_steal_engine.py
+++ b/sniper-main/tests/test_steal_engine.py
@@ -16,8 +16,8 @@ class Offer:
 
 
 def test_is_steal_true(monkeypatch):
-    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: Decimal("100"))
-    offer = Offer("WAW", "JFK", Decimal("70"))
+    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: Decimal("1000"))
+    offer = Offer("WAW", "JFK", Decimal("750"))
     cfg = Config()
     assert steal_engine.is_steal(offer, cfg)
 


### PR DESCRIPTION
## Summary
- update `test_is_steal_true` to use avg=1000PLN and price=750PLN
- add aggregator test for 30 days without gaps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68718e189af0832dbd01d57403d5f485