### PR TITLE
Refactor Config dataclass

### DIFF
--- a/sniper-main/config.py
+++ b/sniper-main/config.py
@@ -1,86 +1,54 @@
 from __future__ import annotations
+from dataclasses import dataclass, asdict
+from decimal import Decimal
+import json, os, pathlib
+from typing import Any
 
-from dataclasses import dataclass
-
-import json
-import os
-from typing import Any, Dict
-
-# Supported configuration keys
-CONFIG_FIELDS = [
-    "origins",
-    "destinations",
-    "one_way",
-    "min_trip_days",
-    "max_trip_days",
-    "max_price",
-    "max_price_total",
-    "top_n",
-    "min_composite_score",
-    "weight_price",
-    "weight_price_per_km",
-    "weight_baseline_diff",
-    "weight_trip_duration",
-    "passengers",
-    "excluded_airlines",
-    "steal_threshold",
-    "max_stops",
-    "max_layover_h",
-    "poll_interval_h",
-    "currency",
-    "telegram_instant",
-    "email_daily",
-]
-
-
-def load_config(path: str | None = None) -> "Config":
-    """Return configuration loaded from *path* or ``config.json``."""
-    cfg_path = path or os.path.join(os.getcwd(), "config.json")
-    with open(cfg_path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-
-    defaults = {
-        "passengers": 1,
-        "max_price_total": None,
-        "excluded_airlines": [],
-        "min_composite_score": 0,
-        "weight_price": 0.4,
-        "weight_price_per_km": 0.3,
-        "weight_baseline_diff": 0.2,
-        "weight_trip_duration": 0.1,
-        "steal_threshold": 0.20,
-        "max_stops": 1,
-        "max_layover_h": 6.0,
-        "poll_interval_h": 6,
-        "currency": "PLN",
-        "telegram_instant": True,
-        "email_daily": True,
-    }
-
-    cfg = {key: data.get(key, defaults.get(key)) for key in CONFIG_FIELDS}
-    return Config(**{k: cfg[k] for k in Config.__dataclass_fields__})
-
-
-__all__ = ["load_config", "Config"]
+_CFG_PATH = pathlib.Path(os.getenv("SNIPER_CONFIG", "config.json"))
 
 
 @dataclass(slots=True)
 class Config:
-    """Default configuration values."""
-
+    # === parametry filtrowania / logiki STEAL ===
+    origins: list[str] = None
+    destinations: list[str] = None
+    one_way: bool = False
     min_trip_days: int = 5
     max_trip_days: int = 14
-    steal_threshold: float = 0.20  # 20%
+    steal_threshold: float = 0.20
     max_stops: int = 1
     max_layover_h: float = 6.0
-    poll_interval_h: int = 6  # co 6 godz.
+    max_total_time_h: float = 30.0
     currency: str = "PLN"
+    poll_interval_h: int = 6
+
+    # === powiadomienia ===
     telegram_instant: bool = True
+    telegram_bot_token: str | None = None
+    telegram_chat_id: str | None = None
     email_daily: bool = True
+    smtp_host: str | None = None
+    smtp_port: int | None = 465
+    smtp_user: str | None = None
+    smtp_pass: str | None = None
+    email_from: str | None = None
+    email_to: str | None = None
+
+    # === Aviasales ===
+    tp_token: str | None = None
+    tp_marker: str | int | None = None
+    domain: str = "https://www.aviasales.com"
 
     @classmethod
-    def from_json(cls, path: str | None = None) -> "Config":
-        return load_config(path)
+    def from_json(cls, path: str | pathlib.Path = _CFG_PATH) -> "Config":
+        data: dict[str, Any] = {}
+        if pathlib.Path(path).exists():
+            with open(path, encoding="utf-8") as fh:
+                data = json.load(fh)
+        # dataclass pola → domyślne, nadpisz z JSON
+        defaults = asdict(cls())        # type: ignore[arg-type]
+        defaults.update(data)
+        filtered = {k: defaults.get(k) for k in cls.__dataclass_fields__}
+        return cls(**filtered)
 
-
-__all__.append("Config")
+__all__ = ["Config"]

--- a/sniper-main/tests/test_config.py
+++ b/sniper-main/tests/test_config.py
@@ -3,7 +3,7 @@ import sys
 import json
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from config import load_config, Config
+from config import Config
 
 
 def test_load_config(tmp_path):
@@ -22,7 +22,7 @@ def test_load_config(tmp_path):
     cfg_file = tmp_path / "config.json"
     cfg_file.write_text(json.dumps(cfg))
 
-    loaded = load_config(str(cfg_file))
+    loaded = Config.from_json(str(cfg_file))
     assert isinstance(loaded, Config)
     assert loaded.min_trip_days == 5
     assert loaded.max_trip_days == 15


### PR DESCRIPTION
## Summary
- simplify config handling via dataclass defaults
- drop unused `load_config` helper
- update unit tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68725e01ef58832db3c1b1ad446c1a6f