### PR TITLE
Clarify notifier config initialization

### DIFF
--- a/sniper-main/notifier.py
+++ b/sniper-main/notifier.py
@@ -4,6 +4,7 @@ import ssl
 from email.mime.text import MIMEText
 from config import Config
 
+# Load configuration once
 cfg = Config.from_json()
 
 bot = Bot(token=cfg.telegram_bot_token)


### PR DESCRIPTION
## Summary
- emphasize that notifier loads configuration once when the module is imported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687262c20394832d8cf79e7f585ae9b5