### PR TITLE
Update config and fetching logic

### DIFF
--- a/sniper-main/sniper-main/aviasales_fetcher.py
+++ b/sniper-main/sniper-main/aviasales_fetcher.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from decimal import Decimal
-from typing import Generator
+import sqlite3
 
 import requests
 from dotenv import load_dotenv
@@ -40,25 +40,29 @@ class AviasalesFetcher:
     def search_prices(
         self,
         origin: str,
-        destination: str,
+        destination: str | None = None,
         departure_at: str | None = None,
         return_at: str | None = None,
+        *,
+        one_way: bool = False,
         currency: str = "pln",
-    ) -> Generator[FlightOffer, None, None]:
-        """
-        Zwraca generator ofert dla danej pary tras.
-        Parametry *departure_at*, *return_at* – YYYY-MM lub YYYY-MM-DD.
-        """
+        limit: int = 100,
+        max_age_h: int = 12,
+    ) -> list[FlightOffer]:
+        """Return a list of offers for a given route."""
 
+        dest_param = destination or ""
         url = (
             f"{self.base_url}/prices_for_dates?"
-            f"origin={origin}&destination={destination}&currency={currency}"
+            f"origin={origin}&destination={dest_param}&currency={currency}"
             f"&token={self.token}"
         )
         if departure_at:
             url += f"&departure_at={departure_at}"
         if return_at:
             url += f"&return_at={return_at}"
+        url += f"&limit={limit}&one_way={'true' if one_way else 'false'}"
+        url += f"&max_age={max_age_h}"
         if self.marker:
             url += f"&marker={self.marker}"
 
@@ -72,13 +76,46 @@ class AviasalesFetcher:
         if not data.get("success"):
             raise AviasalesFetcherError(f"API error: {data.get('error')}")
 
-        for item in data.get("data", []):
-            yield self._to_offer(item)
+        offers = [self._to_offer(item) for item in data.get("data", [])]
+        return [off for off in offers if off]
 
-    # ──────────────────────────────────────────────────────────
+    def save_offers(self, offers: list[FlightOffer], backend: str, *, path: str) -> None:
+        """Persist offers to a SQLite DB (used in tests)."""
+        if backend != "sqlite":
+            raise ValueError("Unsupported backend")
 
-    def _to_offer(self, item: dict) -> FlightOffer:
+        conn = sqlite3.connect(path + ".db")
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS flights (origin TEXT, destination TEXT, price REAL, fetched_at TEXT)"
+        )
+        rows = [
+            (
+                off.origin,
+                off.destination,
+                float(off.price_pln),
+                off.fetched_at.isoformat(),
+            )
+            for off in offers
+        ]
+        cur.executemany("INSERT INTO flights VALUES (?,?,?,?)", rows)
+        conn.commit()
+        conn.close()
+
+    def _to_offer(self, item: dict) -> FlightOffer | None:
         """Mapuje rekord JSON na obiekt FlightOffer."""
+        if not item.get("link"):
+            return None
+
+        found_raw = item.get("found_at")
+        if found_raw:
+            try:
+                fetched_at = dt.datetime.fromisoformat(found_raw)
+            except Exception:
+                return None
+        else:
+            fetched_at = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+
         price_pln = Decimal(str(item["price"]))
 
         dep_raw = item.get("departure_at") or item.get("depart_date")
@@ -86,9 +123,9 @@ class AviasalesFetcher:
 
         depart = dt.date.fromisoformat(dep_raw[:10])
         return_dt = dt.date.fromisoformat(ret_raw[:10]) if ret_raw else None
-        fetched_at = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
 
         deep_link = (
+            f"{self.domain}{item['link']}" if item.get("link") else
             f"{self.domain}/search/"
             f"{item['origin']}{depart.strftime('%d%m')}"
             f"{item['destination']}"
@@ -111,4 +148,38 @@ class AviasalesFetcher:
         )
 
 
-__all__ = ["AviasalesFetcher", "AviasalesFetcherError"]
+def main(argv: list[str] | None = None) -> None:
+    """Simple CLI used in tests."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("origin")
+    parser.add_argument("destination", nargs="?")
+    parser.add_argument("--departure-date", dest="departure", default=None)
+    parser.add_argument("--return-date", dest="return_date", default=None)
+    parser.add_argument("--one-way", action="store_true")
+    parser.add_argument("--currency", default="PLN")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--max-age-h", type=int, default=12)
+    args = parser.parse_args(argv)
+
+    fetcher = AviasalesFetcher()
+    offers = fetcher.search_prices(
+        origin=args.origin,
+        destination=args.destination,
+        departure_at=args.departure,
+        return_at=args.return_date,
+        one_way=args.one_way,
+        currency=args.currency,
+        limit=args.limit,
+        max_age_h=args.max_age_h,
+    )
+
+    if not offers:
+        print("No offers found")
+    else:
+        for off in offers:
+            print(off)
+
+
+__all__ = ["AviasalesFetcher", "AviasalesFetcherError", "main"]

--- a/sniper-main/sniper-main/config.json
+++ b/sniper-main/sniper-main/config.json
@@ -1,14 +1,41 @@
 {
-  "origins":         ["WAW"],
-  "destinations":    ["CNX", "BKK", "FNC", "ROM", "MIL", "BCN", "MAD"],
-  "one_way":         true,
-  "min_trip_days":   2,
-  "max_trip_days":   30,
+  "origins": [
+    "WAW",
+    "WMI",
+    "KRK",
+    "KTW",
+    "GDN",
+    "WRO",
+    "POZ",
+    "BZG",
+    "SZZ",
+    "LUZ",
+    "RZE",
+    "SZY",
+    "IEG",
+    "RDO"
+  ],
+  "destinations": [
+    "CNX",
+    "BKK",
+    "FNC",
+    "ROM",
+    "MIL",
+    "BCN",
+    "MAD",
+    "JFK",
+    "LHR",
+    "DXB",
+    "SIN",
+    "HND"
+  ],
+  "one_way": true,
+  "min_trip_days": 2,
+  "max_trip_days": 30,
   "max_layover_h": 100.0,
   "steal_threshold": 0.0,
   "max_stops": 2,
   "poll_interval_h": 6,
-  
   "telegram_bot_token": "8165648170:AAErTvHw4WfjPQ8D4BJCzclC1-goD1-WWZk",
   "telegram_instant": true
 }


### PR DESCRIPTION
## Summary
- expand origins and destinations in default config
- handle incomplete offers and add simple CLI in `aviasales_fetcher`
- adjust filtering logic in `deal_filter`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68780b025490832d99e9e06a04d71ce4