### PR TITLE
Prevent duplicate offers

### DIFF
--- a/sniper-main/schema.sql
+++ b/sniper-main/schema.sql
@@ -15,6 +15,19 @@ CREATE INDEX IF NOT EXISTS idx_offers_route
 CREATE INDEX IF NOT EXISTS idx_offers_alert
   ON offers_raw (alert_sent);
 
+-- prevent duplicate offers
+CREATE UNIQUE INDEX IF NOT EXISTS idx_offers_unique
+  ON offers_raw (
+    origin,
+    destination,
+    depart_date,
+    return_date,
+    price_pln,
+    airline,
+    stops,
+    deep_link
+  );
+
 -- offers_agg: średnie 30‑dniowe
 CREATE TABLE IF NOT EXISTS offers_agg (
   origin TEXT, destination TEXT,

--- a/sniper-main/sniper-main/db.py
+++ b/sniper-main/sniper-main/db.py
@@ -29,6 +29,29 @@ def insert_offer(offer: FlightOffer, db_path: str = DB_FILE) -> int:
     """Insert *offer* into ``offers_raw`` and return its row id."""
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT id FROM offers_raw
+         WHERE origin=? AND destination=? AND depart_date=? AND return_date IS ?
+           AND price_pln=? AND airline=? AND stops=? AND deep_link=?
+        """,
+        (
+            offer.origin,
+            offer.destination,
+            offer.depart_date.isoformat(),
+            offer.return_date.isoformat() if offer.return_date else None,
+            float(offer.price_pln),
+            offer.airline,
+            offer.stops,
+            offer.deep_link,
+        ),
+    )
+    existing = cur.fetchone()
+    if existing:
+        conn.close()
+        return existing[0]
+
     cur.execute(
         """
         INSERT INTO offers_raw(

--- a/sniper-main/sniper-main/tests/test_insert_offer.py
+++ b/sniper-main/sniper-main/tests/test_insert_offer.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import sqlite3
+from datetime import datetime, timezone, date
+from decimal import Decimal
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from db import init_db, insert_offer
+from models import FlightOffer
+
+
+def make_offer() -> FlightOffer:
+    return FlightOffer(
+        origin="WAW",
+        destination="JFK",
+        depart_date=date(2024, 9, 10),
+        return_date=date(2024, 9, 20),
+        price_pln=Decimal("500"),
+        airline="AA",
+        stops=0,
+        total_flight_time_h=None,
+        max_layover_h=None,
+        deep_link="https://example.com/offer",
+        fetched_at=datetime.now(timezone.utc),
+    )
+
+
+def test_insert_offer_deduplicates(tmp_path):
+    db_file = tmp_path / "test.db"
+    schema_path = os.path.join(os.path.dirname(__file__), "..", "..", "schema.sql")
+    init_db(str(db_file), schema_path=schema_path)
+
+    offer = make_offer()
+    first_id = insert_offer(offer, db_path=str(db_file))
+    second_id = insert_offer(offer, db_path=str(db_file))
+
+    assert first_id == second_id
+
+    conn = sqlite3.connect(db_file)
+    cur = conn.execute("SELECT COUNT(*) FROM offers_raw")
+    count = cur.fetchone()[0]
+    conn.close()
+
+    assert count == 1


### PR DESCRIPTION
## Summary
- ensure offers_raw table has unique index
- prevent inserting duplicate offers
- test deduplication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68780fb06490832da2a507464062e21d