### PR TITLE
Add pairing config and validation

### DIFF
--- a/sniper_main/config.json
+++ b/sniper_main/config.json
@@ -33,9 +33,12 @@
   "min_trip_days": 2,
   "max_trip_days": 30,
   "max_layover_h": 100.0,
-  "steal_threshold": 0.0,
+  "steal_threshold": 0.20,
   "max_stops": 2,
   "poll_interval_h": 6,
   "telegram_bot_token": "8165648170:AAErTvHw4WfjPQ8D4BJCzclC1-goD1-WWZk",
-  "telegram_instant": true
+  "telegram_instant": true,
+  "combine_ow": true,
+  "alert_pair": true,
+  "pair_steal_threshold": 0.20
 }

--- a/sniper_main/requirements.txt
+++ b/sniper_main/requirements.txt
@@ -1,5 +1,6 @@
 requests
 tabulate
+pydantic==2.*
 python-dotenv==1.0.*
 pandas==2.*
 python-telegram-bot==20.7


### PR DESCRIPTION
## Summary
- extend `Config` dataclass with pairing options
- validate pairing and steal thresholds
- provide example values in `config.json`
- include pydantic dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ac5da5168832d82185096ef55ee14