### PR TITLE
Rewrite config with BaseSettings

### DIFF
--- a/sniper_main/aviasales_fetcher.py
+++ b/sniper_main/aviasales_fetcher.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import datetime as dt
 from decimal import Decimal
 import sqlite3
+import os
 
 import requests
 from dotenv import load_dotenv
 
-from .config import Config
 from .models import FlightOffer
 
 load_dotenv()
-CFG = Config.from_json()
 
 
 class AviasalesFetcherError(RuntimeError):
@@ -30,8 +29,8 @@ class AviasalesFetcher:
         base_url: str = "https://api.travelpayouts.com/aviasales/v3",
         domain: str = "https://www.aviasales.com",
     ) -> None:
-        self.token = token or CFG.tp_token or ""
-        self.marker = marker or CFG.tp_marker or ""
+        self.token = token or os.getenv("TP_TOKEN", "")
+        self.marker = marker or os.getenv("TP_MARKER", "")
         self.base_url = base_url.rstrip("/")
         self.domain = domain.rstrip("/")
 

--- a/sniper_main/requirements.txt
+++ b/sniper_main/requirements.txt
@@ -1,6 +1,7 @@
 requests
 tabulate
 pydantic==2.*
+pydantic-settings==2.*
 python-dotenv==1.0.*
 pandas==2.*
 python-telegram-bot==20.7

--- a/sniper_main/steal_engine.py
+++ b/sniper_main/steal_engine.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from .config import Config
+from typing import Any
 from .db import get_last_30d_avg
 from .models import FlightOffer
 
 
-def is_steal(offer: FlightOffer, cfg: Config) -> bool:
+def is_steal(offer: FlightOffer, cfg: Any) -> bool:
     """Return ``True`` if *offer* price is a steal compared to recent average.
 
     Example:

--- a/sniper_main/tests/test_config.py
+++ b/sniper_main/tests/test_config.py
@@ -1,35 +1,13 @@
-import os
-import json
-
-from sniper_main.config import Config
+from sniper_main.config import get_settings, Settings
 
 
-def test_load_config(tmp_path):
-    cfg = {
-        "origins": ["WAW"],
-        "destinations": ["JFK", "LAX"],
-        "one_way": False,
-        "min_trip_days": 5,
-        "max_trip_days": 15,
-        "max_price": 1200,
-        "top_n": 3,
-        "min_composite_score": 55,
-        "excluded_airlines": ["XX"],
-        "extra": "ignored",
-    }
-    cfg_file = tmp_path / "config.json"
-    cfg_file.write_text(json.dumps(cfg))
+def test_settings_from_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc")
+    monkeypatch.setenv("POLL_INTERVAL_H", "3")
+    monkeypatch.setenv("AIRPORTS", '["WAW", "JFK"]')
 
-    loaded = Config.from_json(str(cfg_file))
-    assert isinstance(loaded, Config)
-    assert loaded.min_trip_days == 5
-    assert loaded.max_trip_days == 15
-    # defaults
-    assert loaded.steal_threshold == 0.20
-    assert loaded.max_stops == 1
-    assert loaded.max_layover_h == 6.0
-    assert loaded.poll_interval_h == 6
-    assert loaded.currency == "PLN"
-    assert loaded.telegram_instant is True
-    assert loaded.email_daily is True
-
+    cfg = get_settings()
+    assert isinstance(cfg, Settings)
+    assert cfg.telegram_token == "abc"
+    assert cfg.poll_interval_h == 3
+    assert cfg.airports == ["WAW", "JFK"]

--- a/sniper_main/tests/test_steal_engine.py
+++ b/sniper_main/tests/test_steal_engine.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
 
-from sniper_main.config import Config
 from sniper_main import steal_engine
 
 
@@ -10,6 +9,11 @@ class Offer:
     origin: str
     destination: str
     price_pln: Decimal
+
+
+@dataclass(slots=True)
+class Config:
+    steal_threshold: float = 0.2
 
 
 def test_is_steal_true(monkeypatch):


### PR DESCRIPTION
## Summary
- load config from environment variables using `pydantic-settings`
- adapt `AviasalesFetcher` to read tokens from environment
- update `steal_engine` typing
- adjust tests for new settings
- add `pydantic-settings` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687b86153d14832db147746e92d0cd73