### PR TITLE
Add Click CLI to daily_runner

### DIFF
--- a/sniper_main/requirements.txt
+++ b/sniper_main/requirements.txt
@@ -9,3 +9,4 @@ python-telegram-bot==20.7
 apscheduler==3.10.*
 python-telegram-bot==20.*
 python-dotenv==1.*
+click==8.*


### PR DESCRIPTION
## Summary
- extend `daily_runner.py` with Click-based CLI
- support commands `run`, `fetch`, `report`
- allow optional `--once` and `--date` arguments
- adjust `run_once()` to accept optional date
- add `click` to requirements

## Testing
- `pip install -q -r sniper_main/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ba0167508832da01bf633de23b879