### PR TITLE
Add SQLite migration system

### DIFF
--- a/sniper_main/daily_runner.py
+++ b/sniper_main/daily_runner.py
@@ -18,6 +18,7 @@ from .db import (
     mark_alert_sent,
     get_last_30d_avg,
     DB_FILE,
+    migrate,
 )
 
 # ────────────────────────────────────────────────────────────────
@@ -130,6 +131,7 @@ def cli() -> None:
 @click.option("--date", help="Departure date (YYYY-MM-DD) for manual tests")
 def run(once: bool, date: Optional[str]) -> None:
     """Fetch new offers and process them."""
+    migrate(db_path=DB_FILE)
     if once:
         run_once(date)
     else:
@@ -142,6 +144,7 @@ def run(once: bool, date: Optional[str]) -> None:
 @click.option("--date", help="Departure date (YYYY-MM-DD) for manual tests")
 def fetch(date: Optional[str]) -> None:
     """Fetch offers only and print them."""
+    migrate(db_path=DB_FILE)
     for origin in cfg.origins or []:
         for dest in cfg.destinations or []:
             logging.info("Fetching: %s ➔ %s", origin, dest)
@@ -165,6 +168,7 @@ def fetch(date: Optional[str]) -> None:
 @cli.command()
 def report() -> None:
     """Aggregate history and send daily report."""
+    migrate(db_path=DB_FILE)
     from . import aggregator, daily_report
 
     aggregator.aggregate()

--- a/sniper_main/migrations/001_initial.sql
+++ b/sniper_main/migrations/001_initial.sql
@@ -1,0 +1,54 @@
+-- offers_raw: każda znaleziona oferta
+CREATE TABLE IF NOT EXISTS offers_raw (
+  id INTEGER PRIMARY KEY,
+  origin TEXT, destination TEXT,
+  depart_date DATE, return_date DATE,
+  price_pln NUMERIC, airline TEXT,
+  stops INTEGER, total_time_h REAL, layover_h REAL,
+  deep_link TEXT, fetched_at DATETIME,
+  alert_sent INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_offers_route
+  ON offers_raw (origin, destination, depart_date);
+
+CREATE INDEX IF NOT EXISTS idx_offers_alert
+  ON offers_raw (alert_sent);
+
+-- prevent duplicate offers
+CREATE UNIQUE INDEX IF NOT EXISTS idx_offers_unique
+  ON offers_raw (
+    origin,
+    destination,
+    depart_date,
+    return_date,
+    price_pln,
+    airline,
+    stops,
+    deep_link
+  );
+
+-- offers_agg: średnie 30‑dniowe
+CREATE TABLE IF NOT EXISTS offers_agg (
+  origin TEXT, destination TEXT,
+  day DATE,
+  mean_price NUMERIC,
+  PRIMARY KEY (origin, destination, day)
+);
+
+-- ① Tabela parowanych pseudo-RT (dwie nogi OW)
+CREATE TABLE IF NOT EXISTS offers_pair (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    out_id          INTEGER NOT NULL REFERENCES offers_raw(id) ON DELETE CASCADE,
+    in_id           INTEGER NOT NULL REFERENCES offers_raw(id) ON DELETE CASCADE,
+    origin          TEXT NOT NULL,
+    destination     TEXT NOT NULL,
+    depart_date     DATE NOT NULL,
+    return_date     DATE NOT NULL,
+    price_total_pln NUMERIC NOT NULL,
+    steal_pair      INTEGER NOT NULL DEFAULT 0,
+    fetched_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(out_id, in_id)
+);
+CREATE INDEX IF NOT EXISTS pair_dates_idx
+    ON offers_pair(origin,destination,depart_date);

--- a/sniper_main/migrations/002_example.sql
+++ b/sniper_main/migrations/002_example.sql
@@ -1,0 +1,1 @@
+-- example future migration

--- a/sniper_main/tests/test_aggregator.py
+++ b/sniper_main/tests/test_aggregator.py
@@ -10,14 +10,14 @@ from sniper_main import aggregator
 
 def test_aggregate_30_days_no_gaps(tmp_path):
     db_file = tmp_path / "test.db"
-    schema_path = os.path.join(
+    migrations_dir = os.path.join(
         os.path.dirname(__file__),
         "..",
         "..",
-        "sniper-main",
-        "schema.sql",
+        "sniper_main",
+        "migrations",
     )
-    init_db(str(db_file), schema_path=schema_path)
+    init_db(str(db_file), migrations_dir=migrations_dir)
 
     conn = sqlite3.connect(db_file)
     now = datetime.utcnow()

--- a/sniper_main/tests/test_insert_offer.py
+++ b/sniper_main/tests/test_insert_offer.py
@@ -25,14 +25,14 @@ def make_offer() -> FlightOffer:
 
 def test_insert_offer_deduplicates(tmp_path):
     db_file = tmp_path / "test.db"
-    schema_path = os.path.join(
+    migrations_dir = os.path.join(
         os.path.dirname(__file__),
         "..",
         "..",
-        "sniper-main",
-        "schema.sql",
+        "sniper_main",
+        "migrations",
     )
-    init_db(str(db_file), schema_path=schema_path)
+    init_db(str(db_file), migrations_dir=migrations_dir)
 
     offer = make_offer()
     first_id = insert_offer(offer, db_path=str(db_file))


### PR DESCRIPTION
## Summary
- add migrations directory with initial SQL script
- refactor `db.py` to run incremental migrations
- initialise DB with migrations in tests
- run `migrate()` automatically in `daily_runner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ccb607520832d98a4677150d59350