### PR TITLE
Fix spacing in mailer

### DIFF
--- a/sniper_main/mailer.py
+++ b/sniper_main/mailer.py
@@ -10,6 +10,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def send_email(
     deals: List[Dict],
     smtp_host: str,


### PR DESCRIPTION
## Summary
- ensure there are two blank lines before the `send_email` function

## Testing
- `flake8 sniper_main/mailer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ce99f2224832d8228ff991c1f35e0