### PR TITLE
Fix flake8 E302 in mailer

### DIFF
--- a/sniper_main/mailer.py
+++ b/sniper_main/mailer.py
@@ -7,7 +7,6 @@ from typing import List, Dict
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- ensure exactly two blank lines before `send_email`

## Testing
- `flake8 sniper_main/mailer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687cef27b308832db8d0359dad1cabcf