### PR TITLE
Add seasonality-based steal detection

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -52,3 +52,12 @@ CREATE TABLE IF NOT EXISTS offers_pair (
 );
 CREATE INDEX IF NOT EXISTS pair_dates_idx
     ON offers_pair(origin,destination,depart_date);
+
+-- weekday averages
+CREATE TABLE IF NOT EXISTS weekday_avg (
+  origin TEXT NOT NULL,
+  destination TEXT NOT NULL,
+  weekday INTEGER NOT NULL,
+  avg_price NUMERIC NOT NULL,
+  PRIMARY KEY (origin,destination,weekday)
+);

--- a/sniper_main/daily_runner.py
+++ b/sniper_main/daily_runner.py
@@ -10,7 +10,7 @@ import click
 
 from .aviasales_fetcher import AviasalesFetcher
 from .config import Config
-from .steal_engine import is_steal
+from .steal_engine import is_weekday_steal
 from .pair_engine import process_outbound
 from .notifier import send_telegram
 from . import aggregator, daily_report
@@ -96,7 +96,7 @@ def run_once(dep_date: Optional[str] = None) -> None:
                     logger.info("Utworzono %d STEAL par", len(pair_steals))
 
                 # ── STEAL? ───────────────────────────────────
-                if is_steal(off, cfg):
+                if is_weekday_steal(off, cfg):
                     avg = (
                         get_last_30d_avg(off.origin, off.destination)
                         or off.price_pln
@@ -173,6 +173,7 @@ def report() -> None:
     migrate(db_path=DB_FILE)
 
     aggregator.aggregate()
+    aggregator.store_weekday_averages()
     daily_report.send_daily_report()
 
 

--- a/sniper_main/migrations/003_weekday_avg.sql
+++ b/sniper_main/migrations/003_weekday_avg.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS weekday_avg (
+  origin TEXT NOT NULL,
+  destination TEXT NOT NULL,
+  weekday INTEGER NOT NULL,
+  avg_price NUMERIC NOT NULL,
+  PRIMARY KEY (origin, destination, weekday)
+);

--- a/sniper_main/tests/test_steal_engine.py
+++ b/sniper_main/tests/test_steal_engine.py
@@ -1,5 +1,9 @@
 from dataclasses import dataclass
+from datetime import date
 from decimal import Decimal
+
+import sqlite3
+from datetime import datetime
 
 from sniper_main import steal_engine
 
@@ -8,6 +12,7 @@ from sniper_main import steal_engine
 class Offer:
     origin: str
     destination: str
+    depart_date: date
     price_pln: Decimal
 
 
@@ -16,35 +21,82 @@ class Config:
     steal_threshold: float = 0.2
 
 
-def test_is_steal_true(monkeypatch):
-    monkeypatch.setattr(
-        steal_engine, "get_last_30d_avg", lambda o, d: Decimal("1000")
+def setup_db(tmp_path, prices):
+    db_file = tmp_path / "test.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        "CREATE TABLE weekday_avg (origin TEXT, destination TEXT, weekday INTEGER, avg_price NUMERIC, PRIMARY KEY(origin,destination,weekday))"
     )
-    offer = Offer("WAW", "JFK", Decimal("750"))
-    cfg = Config()
-    assert steal_engine.is_steal(offer, cfg)
-
-
-def test_is_steal_false_price(monkeypatch):
-    monkeypatch.setattr(
-        steal_engine, "get_last_30d_avg", lambda o, d: Decimal("100")
+    conn.execute(
+        "CREATE TABLE offers_raw (origin TEXT, destination TEXT, depart_date DATE, price_pln NUMERIC, fetched_at DATETIME)"
     )
-    offer = Offer("WAW", "JFK", Decimal("90"))
-    cfg = Config()
-    assert not steal_engine.is_steal(offer, cfg)
-
-
-def test_is_steal_no_data(monkeypatch):
-    monkeypatch.setattr(steal_engine, "get_last_30d_avg", lambda o, d: None)
-    offer = Offer("WAW", "JFK", Decimal("50"))
-    cfg = Config()
-    assert not steal_engine.is_steal(offer, cfg)
-
-
-def test_is_steal_non_positive_avg(monkeypatch):
-    monkeypatch.setattr(
-        steal_engine, "get_last_30d_avg", lambda o, d: Decimal("0")
+    for price in prices:
+        conn.execute(
+            "INSERT INTO offers_raw VALUES (?,?,?,?,?)",
+            ("WAW", "JFK", "2024-01-03", price, datetime.utcnow().isoformat()),
+        )
+    conn.execute(
+        "INSERT INTO weekday_avg VALUES (?,?,?,?)",
+        ("WAW", "JFK", 2, 1000.0),
     )
-    offer = Offer("WAW", "JFK", Decimal("10"))
+    conn.commit()
+    conn.close()
+    return db_file
+
+
+def test_is_weekday_steal_true(tmp_path, monkeypatch):
+    db_path = setup_db(tmp_path, [800, 1000, 1200])
+    monkeypatch.setattr(steal_engine, "DB_FILE", str(db_path))
+
+    offer = Offer("WAW", "JFK", date(2024, 1, 3), Decimal("900"))
     cfg = Config()
-    assert not steal_engine.is_steal(offer, cfg)
+    assert steal_engine.is_weekday_steal(offer, cfg)
+
+
+def test_is_weekday_steal_false_price(tmp_path, monkeypatch):
+    db_path = setup_db(tmp_path, [800, 1000, 1200])
+    monkeypatch.setattr(steal_engine, "DB_FILE", str(db_path))
+
+    offer = Offer("WAW", "JFK", date(2024, 1, 3), Decimal("970"))
+    cfg = Config()
+    assert not steal_engine.is_weekday_steal(offer, cfg)
+
+
+def test_is_weekday_steal_no_data(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE weekday_avg (origin TEXT, destination TEXT, weekday INTEGER, avg_price NUMERIC, PRIMARY KEY(origin,destination,weekday))"
+    )
+    conn.execute(
+        "CREATE TABLE offers_raw (origin TEXT, destination TEXT, depart_date DATE, price_pln NUMERIC, fetched_at DATETIME)"
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(steal_engine, "DB_FILE", str(db_path))
+
+    offer = Offer("WAW", "JFK", date(2024, 1, 3), Decimal("50"))
+    cfg = Config()
+    assert not steal_engine.is_weekday_steal(offer, cfg)
+
+
+def test_is_weekday_steal_non_positive_avg(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE weekday_avg (origin TEXT, destination TEXT, weekday INTEGER, avg_price NUMERIC, PRIMARY KEY(origin,destination,weekday))"
+    )
+    conn.execute(
+        "INSERT INTO weekday_avg VALUES (?,?,?,?)",
+        ("WAW", "JFK", 2, 0.0),
+    )
+    conn.execute(
+        "CREATE TABLE offers_raw (origin TEXT, destination TEXT, depart_date DATE, price_pln NUMERIC, fetched_at DATETIME)"
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(steal_engine, "DB_FILE", str(db_path))
+
+    offer = Offer("WAW", "JFK", date(2024, 1, 3), Decimal("10"))
+    cfg = Config()
+    assert not steal_engine.is_weekday_steal(offer, cfg)


### PR DESCRIPTION
## Summary
- compute and store weekday averages for offers
- refresh those averages during daily reporting
- detect steals using weekday-based statistics
- update steal detection tests
- add migration and schema for new `weekday_avg` table

## Testing
- `pip install -r sniper_main/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d6f48a388832db9e543134b83171d