### PR TITLE
Add weekday seasonality to steal detection

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -52,3 +52,12 @@ CREATE TABLE IF NOT EXISTS offers_pair (
 );
 CREATE INDEX IF NOT EXISTS pair_dates_idx
     ON offers_pair(origin,destination,depart_date);
+
+-- Seasonality averages per weekday
+CREATE TABLE IF NOT EXISTS weekday_avg (
+  origin TEXT,
+  destination TEXT,
+  weekday INTEGER,
+  avg_price NUMERIC,
+  PRIMARY KEY (origin, destination, weekday)
+);

--- a/sniper_main/daily_runner.py
+++ b/sniper_main/daily_runner.py
@@ -10,7 +10,7 @@ import click
 
 from .aviasales_fetcher import AviasalesFetcher
 from .config import Config
-from .steal_engine import is_steal
+from .steal_engine import is_weekday_steal
 from .pair_engine import process_outbound
 from .notifier import send_telegram
 from . import aggregator, daily_report
@@ -96,7 +96,7 @@ def run_once(dep_date: Optional[str] = None) -> None:
                     logger.info("Utworzono %d STEAL par", len(pair_steals))
 
                 # ── STEAL? ───────────────────────────────────
-                if is_steal(off, cfg):
+                if is_weekday_steal(off, cfg):
                     avg = (
                         get_last_30d_avg(off.origin, off.destination)
                         or off.price_pln
@@ -173,6 +173,7 @@ def report() -> None:
     migrate(db_path=DB_FILE)
 
     aggregator.aggregate()
+    aggregator.store_weekday_averages()
     daily_report.send_daily_report()
 
 

--- a/sniper_main/migrations/003_weekday_avg.sql
+++ b/sniper_main/migrations/003_weekday_avg.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS weekday_avg (
+    origin TEXT,
+    destination TEXT,
+    weekday INTEGER,
+    avg_price NUMERIC,
+    PRIMARY KEY (origin, destination, weekday)
+);

--- a/sniper_main/steal_engine.py
+++ b/sniper_main/steal_engine.py
@@ -3,27 +3,48 @@ from __future__ import annotations
 import logging
 from decimal import Decimal
 from typing import Any
+import sqlite3
+import pandas as pd
 
-from .db import get_last_30d_avg
+from .db import DB_FILE
 from .models import FlightOffer
 
 logger = logging.getLogger(__name__)
 
 
-def is_steal(offer: FlightOffer, cfg: Any) -> bool:
-    """Return ``True`` if *offer* price is a steal compared to recent average.
+def is_weekday_steal(
+    offer: FlightOffer, cfg: Any, *, db_path: str = DB_FILE
+) -> bool:
+    """Return ``True`` if price is a steal vs weekday average."""
 
-    Example:
-        >>> cfg.steal_threshold = 0.20
-        >>> is_steal(offer(price_pln=Decimal("800")), cfg)  # avg=1000
-        True
-    """
+    weekday = offer.depart_date.weekday()
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT avg_price FROM weekday_avg WHERE origin=? AND destination=? AND weekday=?",
+            (offer.origin, offer.destination, weekday),
+        )
+        row = cur.fetchone()
+        if not row:
+            return False
+        avg_price = Decimal(str(row[0]))
 
-    avg = get_last_30d_avg(offer.origin, offer.destination)
-    if avg is None or avg <= 0:
+        df = pd.read_sql_query(
+            """
+            SELECT price_pln FROM offers_raw
+             WHERE origin=? AND destination=?
+               AND strftime('%w', depart_date)=?
+               AND fetched_at >= DATE('now', '-90 day')
+            """,
+            conn,
+            params=(offer.origin, offer.destination, str(weekday)),
+        )
+
+    if df.empty:
         return False
-    threshold = avg * (Decimal("1") - Decimal(cfg.steal_threshold))
-    return offer.price_pln <= threshold
 
+    std = Decimal(str(df["price_pln"].astype(float).std(ddof=0) or 0))
+    k = Decimal(str(getattr(cfg, "steal_threshold", 1)))
+    threshold = avg_price - k * std
+    return offer.price_pln < threshold
 
-__all__ = ["is_steal"]
+__all__ = ["is_weekday_steal"]

--- a/sniper_main/tests/test_aggregator.py
+++ b/sniper_main/tests/test_aggregator.py
@@ -47,3 +47,55 @@ def test_aggregate_30_days_no_gaps(tmp_path):
     assert row is not None
     expected_avg = sum(prices) / len(prices)
     assert float(row[0]) == pytest.approx(expected_avg)
+
+
+def test_compute_weekday_averages(tmp_path):
+    db_file = tmp_path / "test.db"
+    migrations_dir = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "sniper_main",
+        "migrations",
+    )
+    init_db(str(db_file), migrations_dir=migrations_dir)
+
+    conn = sqlite3.connect(db_file)
+    now = datetime.utcnow()
+    monday = now - timedelta(days=now.weekday())
+    tuesday = monday + timedelta(days=1)
+
+    conn.execute(
+        "INSERT INTO offers_raw (origin, destination, depart_date, price_pln, fetched_at)"
+        " VALUES (?,?,?,?,?)",
+        ("WAW", "JFK", monday.date().isoformat(), 100, now.isoformat()),
+    )
+    conn.execute(
+        "INSERT INTO offers_raw (origin, destination, depart_date, price_pln, fetched_at)"
+        " VALUES (?,?,?,?,?)",
+        ("WAW", "JFK", monday.date().isoformat(), 200, now.isoformat()),
+    )
+    conn.execute(
+        "INSERT INTO offers_raw (origin, destination, depart_date, price_pln, fetched_at)"
+        " VALUES (?,?,?,?,?)",
+        ("WAW", "JFK", tuesday.date().isoformat(), 300, now.isoformat()),
+    )
+    conn.commit()
+    conn.close()
+
+    df = aggregator.compute_weekday_averages(str(db_file))
+    mon = monday.weekday()
+    row = df[(df["origin"] == "WAW") & (df["destination"] == "JFK") & (df["weekday"] == mon)]
+    assert not row.empty
+    assert float(row.iloc[0]["avg_price"]) == pytest.approx(150.0)
+
+    aggregator.store_weekday_averages(str(db_file))
+    conn = sqlite3.connect(db_file)
+    cur = conn.execute(
+        "SELECT avg_price FROM weekday_avg WHERE origin='WAW' AND destination='JFK' AND weekday=?",
+        (mon,),
+    )
+    db_row = cur.fetchone()
+    conn.close()
+    assert db_row is not None
+    assert float(db_row[0]) == pytest.approx(150.0)


### PR DESCRIPTION
## Summary
- compute average price per weekday in aggregator
- persist seasonal averages to new `weekday_avg` table
- call new aggregation in daily report
- evaluate steals relative to weekday history
- include database migration and tests

## Testing
- `pip install -q -r sniper_main/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d784c4058832da434cfaab1fed2e6